### PR TITLE
Fix GUI background not darkening, and fix item tooltips not rendering

### DIFF
--- a/src/main/java/net/mcft/copy/backpacks/client/GuiBackpack.java
+++ b/src/main/java/net/mcft/copy/backpacks/client/GuiBackpack.java
@@ -22,6 +22,13 @@ public class GuiBackpack extends GuiContainer {
 	}
 	
 	@Override
+	public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+		this.drawDefaultBackground();
+		super.drawScreen(mouseX, mouseY, partialTicks);
+		this.renderHoveredToolTip(mouseX, mouseY);
+	}
+	
+	@Override
 	protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
 		String title = (_container.titleLocalized ? _container.title : I18n.format(_container.title));
 		fontRenderer.drawString(title, _container.getBorderSide() + 1, 6, 0x404040);


### PR DESCRIPTION
Currently when the GUI opens the background does not darken. Tooltips are also not rendered when mousing over items. This is because a new change to the drawSreen() method has been introduced that requires you to override it for it to work normally. The code is pretty self explanatory. 

Side note: I don't know your policy on pull requests, if you don't accept small changes to code, feel free to just close this ^^