### PR TITLE
Update death logic so that it correctly adds items to LivingDropsEvent

### DIFF
--- a/src/main/java/net/mcft/copy/backpacks/ProxyCommon.java
+++ b/src/main/java/net/mcft/copy/backpacks/ProxyCommon.java
@@ -276,7 +276,6 @@ public class ProxyCommon {
 		
 		//Only do this logic if it's not configured to place as block on death
 		if (!WearableBackpacks.CONFIG.dropAsBlockOnDeath.get()) {
-			
 			backpack.getType().onEntityWearerDeath(event, backpack);
 		}
 		

--- a/src/main/java/net/mcft/copy/backpacks/api/IBackpackType.java
+++ b/src/main/java/net/mcft/copy/backpacks/api/IBackpackType.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.event.entity.living.LivingDropsEvent;
 
 /** Signalizes that an {@link net.minecraft.item.Item Item} can be equipped as a backpack. */
 public interface IBackpackType {
@@ -42,11 +43,26 @@ public interface IBackpackType {
 	/** Called every game tick when the backpack is equipped, regardless of where. */
 	void onEquippedTick(EntityLivingBase entity, IBackpack backpack);
 	
-	/** Called before the entity wearing this backpack dies and drops the backpack item.
+	/** Called before backpack is broken and should drop as the backpack item.
+	 * <br>
+	 *  Ideally you would make all the items in the backpack drop on the ground, or add them to a container of some kind
+	 *  that drops on the ground.
+	 *  <br>
+	 *  (<b>TheUnderTaker11 note</b>) As far as I can tell, it should be assumed the backpack item itself will be dropped elsewhere.
+	 *  The contents of the bag, not the bag itself, are the only things dropped from this in current implementation.
+	 */
+	void onBackpackDeath(EntityLivingBase entity, IBackpack backpack);
+	
+	/** Called before the Entity dies, ideally you should make 1 of 2 things happen. <br>
+	 * 1. All backpack contents are added to the {@link LivingDropsEvent#getDrops()} collection.
+	 * <br>
+	 * or 2. All backpack contents should be added to an item container, add that container to {@link LivingDropsEvent#getDrops()} collection.
+	 * <p><b>If you do not add the backpack stack itself to the {@link LivingDropsEvent#getDrops()}, it will simply not be dropped! </b>
 	 *  <p>
 	 *  If either the "general.dropAsBlockOnDeath" config setting or "keepInventory"
-	 *  gamerule are enabled, this method won't be called. */
-	void onDeath(EntityLivingBase entity, IBackpack backpack);
+	 *  gamerule are enabled, this method won't be called at all. 
+	 */
+	void onEntityWearerDeath(LivingDropsEvent playerDropsEvent, IBackpack backpack);
 	
 	/** Called when the backpack breaks while being equipped. */
 	void onEquippedBroken(EntityLivingBase entity, IBackpack backpack);

--- a/src/main/java/net/mcft/copy/backpacks/item/ItemBackpack.java
+++ b/src/main/java/net/mcft/copy/backpacks/item/ItemBackpack.java
@@ -1,5 +1,11 @@
 package net.mcft.copy.backpacks.item;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.lang3.ArrayUtils;
+
 import net.mcft.copy.backpacks.WearableBackpacks;
 import net.mcft.copy.backpacks.api.BackpackHelper;
 import net.mcft.copy.backpacks.api.BackpackRegistry;
@@ -12,6 +18,7 @@ import net.mcft.copy.backpacks.misc.BackpackDataItems;
 import net.mcft.copy.backpacks.misc.BackpackSize;
 import net.mcft.copy.backpacks.misc.util.LangUtils;
 import net.mcft.copy.backpacks.misc.util.NbtUtils;
+import net.mcft.copy.backpacks.misc.util.RandomUtils;
 import net.mcft.copy.backpacks.misc.util.WorldUtils;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
@@ -21,6 +28,7 @@ import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnumEnchantmentType;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
@@ -35,12 +43,10 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ISpecialArmor;
+import net.minecraftforge.event.entity.living.LivingDropsEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.OreDictionary;
-import org.apache.commons.lang3.ArrayUtils;
-
-import java.util.List;
 
 // TODO: Implement additional enchantments?
 //       - Holding: Increases backpack size (dungeon loot only?)
@@ -237,19 +243,58 @@ public class ItemBackpack extends Item implements IBackpackType, IDyeableItem, I
 	public void onEquippedTick(EntityLivingBase entity, IBackpack backpack) {  }
 	
 	@Override
-	public void onDeath(EntityLivingBase entity, IBackpack backpack) {
+	public void onBackpackDeath(EntityLivingBase entity, IBackpack backpack) {
 		if (!(backpack.getData() instanceof BackpackDataItems)) return;
 		BackpackDataItems dataItems = (BackpackDataItems)backpack.getData();
 		WorldUtils.dropStacksFromEntity(entity, dataItems.getItems(entity.world, null), 4.0F);
 	}
 	
 	@Override
+	public void onEntityWearerDeath(LivingDropsEvent event, IBackpack backpack) {
+		EntityLivingBase entity = event.getEntityLiving();
+		
+		if (!(backpack.getData() instanceof BackpackDataItems) || entity == null || entity.world.isRemote) return;
+		
+		Collection<EntityItem> drops = event.getDrops();
+		BackpackDataItems dataItems = (BackpackDataItems)backpack.getData();
+		ArrayList<EntityItem> itemsToAdd = new ArrayList<>();
+		for(int i=0; i < dataItems.getItems().getSlots(); i++) {
+			ItemStack stack = dataItems.getItems().getStackInSlot(i);
+			if(!stack.isEmpty()) {
+				//Add some motion logic to make it feel more like normal MC items dropping
+				EntityItem itemEntity = createItemToDropFromEntity(stack, entity);
+				itemsToAdd.add(itemEntity);
+			}
+		}
+		
+		if(!itemsToAdd.isEmpty()) {
+			drops.addAll(itemsToAdd);
+		}
+		
+		// Now add backpack item itself to the drop list
+		if (!backpack.getStack().isEmpty())
+			drops.add(createItemToDropFromEntity(backpack.getStack(), entity));
+		//Remove the Equipped status from the dying entity
+		BackpackHelper.setEquippedBackpack(entity, ItemStack.EMPTY, null);
+	}
+	
+	public static EntityItem createItemToDropFromEntity(ItemStack stack, EntityLivingBase entity) {
+		EntityItem itemEntity = new EntityItem(entity.world,entity.posX,entity.posY+0.3,entity.posZ,stack);
+		float f1 = RandomUtils.getFloat(0.5F);
+		float f2 = RandomUtils.getFloat((float)Math.PI * 2.0F);
+		itemEntity.motionX = -Math.sin(f2) * f1;
+		itemEntity.motionY = 0.2;
+		itemEntity.motionZ = Math.cos(f2) * f1;
+		return itemEntity;
+	}
+	
+	@Override
 	public void onEquippedBroken(EntityLivingBase entity, IBackpack backpack)
-		{ onDeath(entity, backpack); }
+		{ onBackpackDeath(entity, backpack); }
 	
 	@Override
 	public void onFaultyRemoval(EntityLivingBase entity, IBackpack backpack)
-		{ onDeath(entity, backpack); }
+		{ onBackpackDeath(entity, backpack); }
 	
 	@Override
 	public void onBlockBreak(TileEntity tileEntity, IBackpack backpack) {

--- a/src/main/java/net/mcft/copy/backpacks/item/ItemBackpack.java
+++ b/src/main/java/net/mcft/copy/backpacks/item/ItemBackpack.java
@@ -262,7 +262,7 @@ public class ItemBackpack extends Item implements IBackpackType, IDyeableItem, I
 			ItemStack stack = dataItems.getItems().getStackInSlot(i);
 			if(!stack.isEmpty()) {
 				//Add some motion logic to make it feel more like normal MC items dropping
-				EntityItem itemEntity = createItemToDropFromEntity(stack, entity);
+				EntityItem itemEntity = WorldUtils.createItemToDropFromEntity(stack, entity);
 				itemsToAdd.add(itemEntity);
 			}
 		}
@@ -273,19 +273,9 @@ public class ItemBackpack extends Item implements IBackpackType, IDyeableItem, I
 		
 		// Now add backpack item itself to the drop list
 		if (!backpack.getStack().isEmpty())
-			drops.add(createItemToDropFromEntity(backpack.getStack(), entity));
+			drops.add(WorldUtils.createItemToDropFromEntity(backpack.getStack(), entity));
 		//Remove the Equipped status from the dying entity
 		BackpackHelper.setEquippedBackpack(entity, ItemStack.EMPTY, null);
-	}
-	
-	public static EntityItem createItemToDropFromEntity(ItemStack stack, EntityLivingBase entity) {
-		EntityItem itemEntity = new EntityItem(entity.world,entity.posX,entity.posY+0.3,entity.posZ,stack);
-		float f1 = RandomUtils.getFloat(0.5F);
-		float f2 = RandomUtils.getFloat((float)Math.PI * 2.0F);
-		itemEntity.motionX = -Math.sin(f2) * f1;
-		itemEntity.motionY = 0.2;
-		itemEntity.motionZ = Math.cos(f2) * f1;
-		return itemEntity;
 	}
 	
 	@Override

--- a/src/main/java/net/mcft/copy/backpacks/misc/util/WorldUtils.java
+++ b/src/main/java/net/mcft/copy/backpacks/misc/util/WorldUtils.java
@@ -1,6 +1,7 @@
 package net.mcft.copy.backpacks.misc.util;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -87,6 +88,21 @@ public final class WorldUtils {
 		}
 		return item;
 	}
+	
+	/** Creates an EntityItem with momentum and location as if it was dropped from the given entity on death. 
+	 * <br>
+	 * Does NOT spawn this EntityItem into the world, simply creates the object and gives it Vanilla-like momentum values
+	 */
+	public static EntityItem createItemToDropFromEntity(ItemStack stack, EntityLivingBase entity) {
+		EntityItem itemEntity = new EntityItem(entity.world,entity.posX,entity.posY+0.3,entity.posZ,stack);
+		float f1 = RandomUtils.getFloat(0.5F);
+		float f2 = RandomUtils.getFloat((float)Math.PI * 2.0F);
+		itemEntity.motionX = -Math.sin(f2) * f1;
+		itemEntity.motionY = 0.2;
+		itemEntity.motionZ = Math.cos(f2) * f1;
+		return itemEntity;
+	}
+	
 	/** Spawns multiple ItemStacks as if they were dropped from an entity on death. */
 	public static void dropStacksFromEntity(Entity entity, Iterable<ItemStack> stacks, float speed) {
 		for (ItemStack stack : stacks) dropStackFromEntity(entity, stack, speed);


### PR DESCRIPTION
Previously the mod manually spawned the items into the world, completely bypassing/negating any gravestone mods.

Also split the "onDeath(EntityLivingBase entity, IBackpack backpack)" method of IBackpackType into 2 different methods, because calling it "onDeath" wasn't really specific enough anyways.

I haven't tested this _super_ thoroughly or anything, but here is the current test cases I've done so far in dev.    

These 5 test cases were all done with just this mod and [Corpse mod](https://www.curseforge.com/minecraft/mc-mods/corpse) installed, and all test had 3 stacks of orange wool in the backpack unless otherwise specified.      
1. Blowing up placed backpack with TNT
2. Breaking backpack without holding shift (so all contents fell on ground)
3. Blowing up player with backpack on
4. Player dying from fall damage with backpack on.
5. Player dying with completely full inventory and completely full backpack.

These 4 test cases were done with ONLY this mod installed. All 4 test had 3 stacks of orange wool in the backpack.      
1. Blowing up placed backpack with TNT
2. Breaking backpack without holding shift (so all contents fell on ground)
3. Blowing up player with backpack on
4. Player dying from fall damage with backpack on.

All test cases for both mod situations worked as expected. (With items either dropping on ground, or going into the corpse as they should). All test were done with dropAsBlockOnDeath=false, since my logic excludes anything special/different from your code from happening when that is true, and I don't feel like doing a bunch of testing again with that value being true.